### PR TITLE
change ShaderCOptions.includeDirs to an array of C strings

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -12,3 +12,5 @@ The incomplete list of individuals below have provided patches or otherwise
 contributed to the project prior to the project being hosted on GitHub. See the
 GitHub commit log for a list of recent contributors. We would like to thank
 everyone who has contributed to the project in any way.
+
+* __[Sam Loeschen](https://github.com/samloeschen)__

--- a/examples/02-runtime-shaderc/src/main.zig
+++ b/examples/02-runtime-shaderc/src/main.zig
@@ -103,7 +103,7 @@ pub fn buildProgram(allocator: std.mem.Allocator) !bgfx.ProgramHandle {
     const path = try std.fs.path.joinZ(allocator, &.{ exe_dir, "..", "include", "shaders" });
     defer allocator.free(path);
 
-    var includes = [_][:0]const u8{path};
+    var includes = [_][*c]const u8{path};
 
     // Compile fs shader
     var fs_shader_options = shaderc.createDefaultOptionsForRenderer(bgfx.getRendererType());

--- a/src/shaderc.zig
+++ b/src/shaderc.zig
@@ -220,8 +220,8 @@ pub const ShadercOptions = struct {
     inputFilePath: ?[:0]const u8 = null,
     outputFilePath: ?[:0]const u8 = null,
     includeDirs: ?[][*c]const u8 = null,
-    defines: ?[][:0]const u8 = null,
-    dependencies: ?[][:0]const u8 = null,
+    defines: ?[][*c]const u8 = null,
+    dependencies: ?[][*c]const u8 = null,
 
     disasm: bool = false,
     raw: bool = false,

--- a/src/shaderc.zig
+++ b/src/shaderc.zig
@@ -219,7 +219,7 @@ pub const ShadercOptions = struct {
     profile: Profile,
     inputFilePath: ?[:0]const u8 = null,
     outputFilePath: ?[:0]const u8 = null,
-    includeDirs: ?[][:0]const u8 = null,
+    includeDirs: ?[][*c]const u8 = null,
     defines: ?[][:0]const u8 = null,
     dependencies: ?[][:0]const u8 = null,
 


### PR DESCRIPTION
Avoids segfault when providing more than one include path. `[:0]const u8` strings seem to work fine everywhere else, but includeDirs needs to be a `[*c]const u8` to keep shaderc happy